### PR TITLE
Add SonarQube integration

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -2,6 +2,8 @@ name: Build And Deploy
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly SonarQube analysis (Monday 3:00 UTC)
   push:
     branches: ['**']
   pull_request:
@@ -26,6 +28,7 @@ jobs:
       project-name: plaintext-root
       database-name: plaintext_root
       dev-url: 'http://192.168.1.224:1123'
+      sonar-enabled: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     # Pass secrets explicitly. `secrets: inherit` only works when the caller
     # and the reusable workflow live under the same owner; this caller is in
     # Plaintext-Gmbh while the reusable workflow is in daniel-marthaler/* —

--- a/build
+++ b/build
@@ -63,8 +63,8 @@ if [ -n "$COMMAND" ]; then
     # Restart on exit if it was stopped during NAS connectivity check
     trap 'restart_twingate_if_needed' EXIT
 
-    # Check if command is a sequence of digits (multi-command execution)
-    if [[ "$COMMAND" =~ ^[0-9]+$ ]] && [ ${#COMMAND} -gt 1 ]; then
+    # Check if command is a sequence of digits/s (multi-command execution)
+    if [[ "$COMMAND" =~ ^[0-9s]+$ ]] && [ ${#COMMAND} -gt 1 ]; then
         echo -e "${BLUE}=== Executing command sequence: ${COMMAND} ===${NC}"
 
         for (( i=0; i<${#COMMAND}; i++ )); do
@@ -145,6 +145,10 @@ if [ -n "$COMMAND" ]; then
 
         deploy-prod-healthcheck)
             deploy_to_prod "true" || exit 1
+            ;;
+
+        s|sonar)
+            do_sonar || exit 1
             ;;
 
         setup-bluegreen)


### PR DESCRIPTION
## Summary
- Add `./build s` and `./build 56s` for SonarQube analysis
- Add weekly cron schedule (Monday 3:00 UTC) for automated SonarQube analysis
- Requires SONAR_TOKEN GitHub secret

## Test plan
- [ ] Run `./build s` locally once SonarQube is running
- [ ] Verify weekly cron trigger works

🤖 Generated with [Claude Code](https://claude.com/claude-code)