### PR TITLE
fix(security): mark theme cookies Secure + SameSite=Lax

### DIFF
--- a/plaintext-root-webapp/src/main/java/ch/plaintext/boot/plugins/jsf/userprofile/UserPreferencesBackingBean.java
+++ b/plaintext-root-webapp/src/main/java/ch/plaintext/boot/plugins/jsf/userprofile/UserPreferencesBackingBean.java
@@ -400,7 +400,9 @@ public class UserPreferencesBackingBean implements Serializable {
             Cookie cookie = new Cookie("plaintext-theme", theme);
             cookie.setPath("/");
             cookie.setMaxAge(365 * 24 * 60 * 60); // 1 year
-            cookie.setHttpOnly(false); // Allow JavaScript access
+            cookie.setHttpOnly(false); // theme is read client-side via JavaScript
+            cookie.setSecure(true);    // HTTPS only; harmless on http://localhost dev
+            cookie.setAttribute("SameSite", "Lax");
             response.addCookie(cookie);
             log.debug("Saved theme to cookie: {}", theme);
         } catch (Exception e) {

--- a/plaintext-root-webapp/src/main/java/ch/plaintext/boot/web/UserPreferencesRestController.java
+++ b/plaintext-root-webapp/src/main/java/ch/plaintext/boot/web/UserPreferencesRestController.java
@@ -336,7 +336,9 @@ public class UserPreferencesRestController {
             Cookie cookie = new Cookie(cookieName, value);
             cookie.setPath("/");
             cookie.setMaxAge(365 * 24 * 60 * 60); // 1 year
-            cookie.setHttpOnly(false); // Allow JavaScript access
+            cookie.setHttpOnly(false); // theme is read client-side via JavaScript
+            cookie.setSecure(true);    // HTTPS only; harmless on http://localhost dev
+            cookie.setAttribute("SameSite", "Lax");
             response.addCookie(cookie);
         } catch (Exception e) {
             log.error("Error saving cookie '{}': {}", cookieName, e.getMessage(), e);


### PR DESCRIPTION
## Closes CodeQL alerts

- Alert #4 — `java/insecure-cookie` in `UserPreferencesBackingBean.java:404`
- Alert #20 — `java/insecure-cookie` in `UserPreferencesRestController.java:340`

## Was

Two theme-cookie write paths were flagged because they did not set the `Secure` attribute. The theme is read client-side via JavaScript, so `HttpOnly` must stay `false`, but the cookie should still be HTTPS-only and have a `SameSite` policy.

Both call sites now set:

```java
cookie.setSecure(true);
cookie.setAttribute(\"SameSite\", \"Lax\");
```

## Dev impact

`Secure=true` makes the cookie non-functional on `http://localhost`. That's harmless — the theme falls back to the default until the user toggles it on the live site. Production runs on HTTPS, so cookies behave as before.