### PR TITLE
fix(security): stop leaking exception messages in REST error responses

### DIFF
--- a/plaintext-root-webapp/src/main/java/ch/plaintext/boot/web/UserPreferencesRestController.java
+++ b/plaintext-root-webapp/src/main/java/ch/plaintext/boot/web/UserPreferencesRestController.java
@@ -159,7 +159,7 @@ public class UserPreferencesRestController {
             return ResponseEntity.ok("OK");
         } catch (Exception e) {
             log.error("Error saving preferences", e);
-            return ResponseEntity.status(500).body("ERROR: " + e.getMessage());
+            return ResponseEntity.status(500).body("ERROR: Internal server error");
         }
     }
 
@@ -216,7 +216,7 @@ public class UserPreferencesRestController {
             return ResponseEntity.ok("OK");
         } catch (Exception e) {
             log.error("Error adding custom color", e);
-            return ResponseEntity.status(500).body("ERROR: " + e.getMessage());
+            return ResponseEntity.status(500).body("ERROR: Internal server error");
         }
     }
 
@@ -269,7 +269,7 @@ public class UserPreferencesRestController {
             return ResponseEntity.ok("OK");
         } catch (Exception e) {
             log.error("Error deleting color", e);
-            return ResponseEntity.status(500).body("ERROR: " + e.getMessage());
+            return ResponseEntity.status(500).body("ERROR: Internal server error");
         }
     }
 
@@ -310,7 +310,7 @@ public class UserPreferencesRestController {
             return ResponseEntity.ok("OK");
         } catch (Exception e) {
             log.error("Error restoring colors", e);
-            return ResponseEntity.status(500).body("ERROR: " + e.getMessage());
+            return ResponseEntity.status(500).body("ERROR: Internal server error");
         }
     }
 


### PR DESCRIPTION
## Closes CodeQL alerts

- #19, #24, #25, #26 — `java/error-message-exposure` in `UserPreferencesRestController.java` (4 sites: lines 162, 219, 272, 313)

## Was

Each error path returned the raw exception message to the HTTP client:

```java
return ResponseEntity.status(500).body(\"ERROR: \" + e.getMessage());
```

That body is sent to the browser. Exception messages can leak SQL fragments, file paths, internal IDs etc. The full stack trace already goes to the server log via `log.error(\"…\", e)` — that's where it belongs.

All four call sites now return a generic `\"ERROR: Internal server error\"`. The server-side log keeps the full detail.